### PR TITLE
fix breakpoints don't trigger when hit

### DIFF
--- a/src/debugger.js
+++ b/src/debugger.js
@@ -1425,6 +1425,15 @@ Debugger.prototype = {
             cmd: this.JDWP.Commands.lineTable(methodinfo.owningclass, methodinfo),
         })
             .then(function (linetable, methodinfo) {
+                // if the request failed, just return a blank table
+                if (linetable.errorcode) {
+                    linetable = {
+                        errorcode: linetable.errorcode,
+                        start: '00000000000000000000000000000000',
+                        end: '00000000000000000000000000000000',
+                        lines:[],
+                    }
+                }
                 // the linetable does not correlate code indexes with line numbers
                 // - location searching relies on the table being ordered by code indexes
                 linetable.lines.sort(function (a, b) {

--- a/src/jdwp.js
+++ b/src/jdwp.js
@@ -109,7 +109,10 @@ function _JDWP() {
 			return;
 		}
 
-		this.decoded = {empty:true};
+		this.decoded = {
+            empty: true,
+            errorcode: this.errorcode,
+        };
 	}
 
 	this.decodereply = function(ths,s) {


### PR DESCRIPTION
Use a dummy (empty) linetable if the linetable JDWP command fails.
Closes #34