### PR TITLE
Allow customised install arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ The following settings are used to configure the debugger:
                 "staleBuild": "warn",
 
                 // Fully qualified path to the AndroidManifest.xml file compiled in the APK. Default: appSrcRoot/AndroidManifest.xml
-                "manifestFile": "${workspaceRoot}/app/src/main/AndroidManifest.xml"
+                "manifestFile": "${workspaceRoot}/app/src/main/AndroidManifest.xml",
+
+                // APK install arguments passed to the Android package manager. Run 'adb shell pm' to show valid arguments. Default: ["-r"]
+                "pmInstallArgs": ["-r"]
             }
         ]
     }

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ The following settings are used to configure the debugger:
                 "manifestFile": "${workspaceRoot}/app/src/main/AndroidManifest.xml",
 
                 // APK install arguments passed to the Android package manager. Run 'adb shell pm' to show valid arguments. Default: ["-r"]
-                "pmInstallArgs": ["-r"]
+                "pmInstallArgs": ["-r"],
+
+                // Manually specify the activity to run when the app is started.
+                "launchActivity": ".MainActivity"
             }
         ]
     }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
                                 "description": "Number of entries to display in call stack views (for locations outside of the project source). 0 shows the entire call stack. Default: 1",
                                 "default": 1
                             },
+                            "launchActivity": {
+                                "type": "string",
+                                "description": "Manually specify the activity to run when the app is started.",
+                                "default": ""
+                            },
                             "logcatPort": {
                                 "type": "integer",
                                 "description": "Port number to use for the internal logcat websocket link. Changes to this value only apply when the extension is restarted. Default: 7038",
@@ -107,7 +112,7 @@
                             "trace": {
                                 "type": "boolean",
                                 "description": "Set to true to output debugging logs for diagnostics",
-                                "default": "false"
+                                "default": false
                             }
                         }
                     }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
                                 "description": "Overrides the default location of AndroidManifest.xml",
                                 "default": "${workspaceRoot}/app/src/main/AndroidManifest.xml"
                             },
+                            "pmInstallArgs": {
+                                "type": "array",
+                                "description":"APK install arguments passed to the Android package manager. Run 'adb shell pm' to show valid arguments. Default: [\"-r\"]",
+                                "default": ["-r"]
+                            },
                             "staleBuild": {
                                 "type": "string",
                                 "description": "Launch behaviour if source files have been saved after the APK was built. One of: [\"ignore\" \"warn\" \"stop\"]. Default: \"warn\"",

--- a/src/debugMain.js
+++ b/src/debugMain.js
@@ -422,6 +422,8 @@ class AndroidDebugSession extends DebugSession {
             if (m) {
                 return $.Deferred().rejectWith(this, [new Error('Installation failed. ' + m[0])]);
             }
+            // now the 'pm install' command can have user-defined arguments, we must check that the command
+            // is not rejected because of bad values
             m = stdout.match(/^java.lang.IllegalArgumentException:.+/m);
             if (m) {
                 return $.Deferred().rejectWith(this, [new Error('Installation failed. ' + m[0])]);


### PR DESCRIPTION
Create `pmInstallArgs` launch configuration parameter, allowing an array of strings to be passed as arguments to the `pm install <apk>` command.

Fixes #73 