### PR TITLE
support custom launch arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,31 +34,61 @@ The following settings are used to configure the debugger:
         "version": "0.2.0",
         "configurations": [
             {
-                // configuration type, request  and name. "launch" is used to deploy the app to your device and start a debugging session
+                // configuration type, request  and name. "launch" is used to deploy the app
+                // to your device and start a debugging session.
                 "type": "android",
                 "request": "launch",
                 "name": "Launch App",
 
-                // Location of the App source files. This value must point to the root of your App source tree (containing AndroidManifest.xml)
+                // Location of the App source files. This value must point to the root of
+                // your App source tree (containing AndroidManifest.xml).
                 "appSrcRoot": "${workspaceRoot}/app/src/main",
 
-                // Fully qualified path to the built APK (Android Application Package)
+                // Fully qualified path to the built APK (Android Application Package).
                 "apkFile": "${workspaceRoot}/app/build/outputs/apk/app-debug.apk",
 
-                // Port number to connect to the local ADB (Android Debug Bridge) instance. Default: 5037
+                // Port number to connect to the local ADB (Android Debug Bridge) instance.
+                // Default: 5037
                 "adbPort": 5037,
 
-                // Launch behaviour if source files have been saved after the APK was built. One of: [ ignore warn stop ]. Default: warn
+                // Automatically launch 'adb start-server' if not already started.
+                // Default: true
+                "autoStartADB": true,
+
+                // Launch behaviour if source files have been saved after the APK was built.
+                // One of: [ ignore warn stop ]. Default: warn
                 "staleBuild": "warn",
 
-                // Fully qualified path to the AndroidManifest.xml file compiled in the APK. Default: appSrcRoot/AndroidManifest.xml
+                // Target Device ID (as indicated by 'adb devices').
+                // Use this to specify which device is used for deployment
+                // when multiple devices are connected.
+                "targetDevice": "",
+
+                // Fully qualified path to the AndroidManifest.xml file compiled into the APK.
+                // Default: "${appSrcRoot}/AndroidManifest.xml"
                 "manifestFile": "${workspaceRoot}/app/src/main/AndroidManifest.xml",
 
-                // APK install arguments passed to the Android package manager. Run 'adb shell pm' to show valid arguments. Default: ["-r"]
+                // Custom arguments passed to the Android package manager to install the app.
+                // Run 'adb shell pm' to show valid arguments. Default: ["-r"]
                 "pmInstallArgs": ["-r"],
 
-                // Manually specify the activity to run when the app is started.
-                "launchActivity": ".MainActivity"
+                // Custom arguments passed to the Android application manager to start the app.
+                // Run `adb shell am` to show valid arguments.
+                // Note that `-D` is required to enable debugging.
+                "amStartArgs": [
+                    "-D",
+                    "--activity-brought-to-front",
+                    "-a android.intent.action.MAIN",
+                    "-c android.intent.category.LAUNCHER",
+                    "-n package.name/launch.activity"
+                ],
+
+                // Manually specify the activity to run when the app is started. This option is
+                // mutually exclusive with "amStartArgs".
+                "launchActivity": ".MainActivity",
+
+                // Set to true to output debugging logs for diagnostics.
+                "trace": false
             }
         ]
     }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,17 @@
                             "adbPort"
                         ],
                         "properties": {
+                            "amStartArgs": {
+                                "type": "array",
+                                "description": "Custom arguments to pass to the Android application manager to start the app. Run `adb shell am` to show valid arguments. Note that `-D` is required to enable debugging.\r\nBe careful using this option - you must specify the correct parameters or the app will not start.\r\n\r\nThis option is incompatible with the `launchActivity` option.",
+                                "default": [
+                                    "-D",
+                                    "--activity-brought-to-front",
+                                    "-a android.intent.action.MAIN",
+                                    "-c android.intent.category.LAUNCHER",
+                                    "-n package.name/launch.activity"
+                                ]
+                            },
                             "appSrcRoot": {
                                 "type": "string",
                                 "description": "Location of the App source files. This value must point to the root of your App source tree (containing AndroidManifest.xml)",

--- a/src/debugger-types.js
+++ b/src/debugger-types.js
@@ -9,13 +9,14 @@ class BuildInfo {
      * @param {string} pkgname 
      * @param {Map<string,PackageInfo>} packages 
      * @param {string} launchActivity 
+     * @param {string[]} amCommandArgs custom arguments passed to `am start`
      */
-    constructor(pkgname, packages, launchActivity) {
+    constructor(pkgname, packages, launchActivity, amCommandArgs) {
         this.pkgname = pkgname;
         this.packages = packages;
         this.launchActivity = launchActivity;
         /** the arguments passed to `am start` */
-        this.startCommandArgs = [
+        this.startCommandArgs = amCommandArgs || [
             '-D',   // enable debugging
             '--activity-brought-to-front',
             '-a android.intent.action.MAIN',


### PR DESCRIPTION
Fixes #82 

Add support for a new `amStartArgs` launch configuration property to allow users to define their own `am start` arguments. This is similar to the existing `pmInstallArgs` launch option, which allows customisation of the APK installation.

The new property takes a list of strings defining the arguments to append to `am start`. The arguments must include everything (including `-D` to allow debugging and the name of the activity/component to launch).

```json
"amStartArgs": [
  "-D",
  "--activity-brought-to-front",
  "-a android.intent.action.MAIN",
  "-c android.intent.category.LAUNCHER",
  "-n package.name/launch.activity"
]
```
(The user must replace `package.name/launch.activity` with the name of the component to launch).

Because `amStartArgs` must include the component to launch, this option is incompatible with the `launchActivity` option.

The output from the `am start` command is now printed to the Debug Console, showing which component is being launched.