### PR TITLE
Attach to running app

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             ]
         },
 		{
-			"name": "Server",
+			"name": "Debugger Server",
 			"type": "node",
 			"request": "launch",
 			"cwd": "${workspaceRoot}",
@@ -35,8 +35,8 @@
     ],
 	"compounds": [
 		{
-			"name": "Extension + Server",
-			"configurations": [ "Launch Extension", "Server" ]
+			"name": "Extension + Debugger",
+			"configurations": [ "Launch Extension", "Debugger Server" ]
 		}
 	]
 }

--- a/extension.js
+++ b/extension.js
@@ -22,7 +22,7 @@ function activate(context) {
         vscode.commands.registerCommand('PickAndroidProcess', async () => {
             const o = await selectAndroidProcessID(vscode);
             // the debugger requires a string value to be returned
-            return (o && typeof o === 'object') ? JSON.stringify(o) : '';
+            return JSON.stringify(o);
         }),
     ];
 

--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,7 @@
 const vscode = require('vscode');
 const { AndroidContentProvider } = require('./src/contentprovider');
 const { openLogcatWindow } = require('./src/logcat');
+const { selectAndroidProcessID } = require('./src/process-attach');
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -16,6 +17,12 @@ function activate(context) {
         // add the view logcat handler
         vscode.commands.registerCommand('android-dev-ext.view_logcat', () => {
             openLogcatWindow(vscode);
+        }),
+        // add the process picker handler - used to choose a PID to attach to
+        vscode.commands.registerCommand('PickAndroidProcess', async () => {
+            const o = await selectAndroidProcessID(vscode);
+            // the debugger requires a string value to be returned
+            return (o && typeof o === 'object') ? JSON.stringify(o) : '';
         }),
     ];
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "theme": "dark"
     },
     "activationEvents": [
-        "onCommand:android-dev-ext.view_logcat"
+        "onCommand:android-dev-ext.view_logcat",
+        "onCommand:PickAndroidProcess"
     ],
     "repository": {
         "type": "git",
@@ -30,6 +31,10 @@
             {
                 "command": "android-dev-ext.view_logcat",
                 "title": "Android: View Logcat"
+            },
+            {
+                "command": "PickAndroidProcess",
+                "title": "Android: Attach to process"
             }
         ],
         "breakpoints": [
@@ -117,21 +122,63 @@
                                 "default": false
                             }
                         }
+                    },
+                    "attach": {
+                        "required": [
+                            "appSrcRoot",
+                            "adbPort",
+                            "processId"
+                        ],
+                        "properties": {
+                            "appSrcRoot": {
+                                "type": "string",
+                                "description": "Location of the App source files. This value must point to the root of your App source tree (containing AndroidManifest.xml)",
+                                "default": "${workspaceRoot}/app/src/main"
+                            },
+                            "adbPort": {
+                                "type": "integer",
+                                "description": "Port number to connect to the local ADB (Android Debug Bridge) instance. Default: 5037",
+                                "default": 5037
+                            },
+                            "processId": {
+                                "type": "string",
+                                "description": "PID of process to attach to. This can be set to \"${command:PickAndroidProcess}\" to display a list of debuggable PIDs to choose from during launch.",
+                                "default": "${command:PickAndroidProcess}"
+                            },
+                            "targetDevice": {
+                                "type": "string",
+                                "description": "Target Device ID (as indicated by 'adb devices'). Use this to specify which device is used when multiple devices are connected.",
+                                "default": ""
+                            },
+                            "trace": {
+                                "type": "boolean",
+                                "description": "Set to true to output debugging logs for diagnostics",
+                                "default": false
+                            }
+                        }
                     }
                 },
                 "initialConfigurations": [
                     {
                         "type": "android",
-                        "name": "Android",
                         "request": "launch",
+                        "name": "Android launch",
                         "appSrcRoot": "${workspaceRoot}/app/src/main",
                         "apkFile": "${workspaceRoot}/app/build/outputs/apk/debug/app-debug.apk",
                         "adbPort": 5037
+                    },
+                    {
+                        "type": "android",
+                        "request": "attach",
+                        "name": "Android attach",
+                        "appSrcRoot": "${workspaceRoot}/app/src/main",
+                        "adbPort": 5037,
+                        "processId": "${command:PickProcess}"
                     }
                 ],
                 "configurationSnippets": [
                     {
-                        "label": "Android: Launch Configuration",
+                        "label": "Android: Launch Application",
                         "description": "A new configuration for launching an Android app debugging session",
                         "body": {
                             "type": "android",
@@ -140,6 +187,18 @@
                             "appSrcRoot": "^\"\\${workspaceRoot}/app/src/main\"",
                             "apkFile": "^\"\\${workspaceRoot}/app/build/outputs/apk/debug/app-debug.apk\"",
                             "adbPort": 5037
+                        }
+                    },
+                    {
+                        "label": "Android: Attach to Process",
+                        "description": "A new configuration for attaching to a running Android app process",
+                        "body": {
+                            "type": "android",
+                            "request": "attach",
+                            "name": "${2:Attach to Application}",
+                            "appSrcRoot": "^\"\\${workspaceRoot}/app/src/main\"",
+                            "adbPort": 5037,
+                            "processId": "^\"\\${command:PickProcess}\""
                         }
                     }
                 ],

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
                         "body": {
                             "type": "android",
                             "request": "launch",
-                            "name": "${2:Launch App}",
+                            "name": "${2:Android Launch}",
                             "appSrcRoot": "^\"\\${workspaceRoot}/app/src/main\"",
                             "apkFile": "^\"\\${workspaceRoot}/app/build/outputs/apk/debug/app-debug.apk\"",
                             "adbPort": 5037
@@ -191,7 +191,7 @@
                         "body": {
                             "type": "android",
                             "request": "attach",
-                            "name": "${2:Attach to App}",
+                            "name": "${2:Android Attach}",
                             "appSrcRoot": "^\"\\${workspaceRoot}/app/src/main\"",
                             "adbPort": 5037,
                             "processId": "^\"\\${command:PickAndroidProcess}\""

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
                             },
                             "processId": {
                                 "type": "string",
-                                "description": "PID of process to attach to. This can be set to \"${command:PickAndroidProcess}\" to display a list of debuggable PIDs to choose from during launch.",
+                                "description": "PID of process to attach to.\n\"${command:PickAndroidProcess}\" will display a list of debuggable PIDs to choose from during launch.",
                                 "default": "${command:PickAndroidProcess}"
                             },
                             "targetDevice": {
@@ -173,7 +173,7 @@
                         "name": "Android attach",
                         "appSrcRoot": "${workspaceRoot}/app/src/main",
                         "adbPort": 5037,
-                        "processId": "${command:PickProcess}"
+                        "processId": "${command:PickAndroidProcess}"
                     }
                 ],
                 "configurationSnippets": [
@@ -195,10 +195,10 @@
                         "body": {
                             "type": "android",
                             "request": "attach",
-                            "name": "${2:Attach to Application}",
+                            "name": "${2:Attach to App}",
                             "appSrcRoot": "^\"\\${workspaceRoot}/app/src/main\"",
                             "adbPort": 5037,
-                            "processId": "^\"\\${command:PickProcess}\""
+                            "processId": "^\"\\${command:PickAndroidProcess}\""
                         }
                     }
                 ],

--- a/package.json
+++ b/package.json
@@ -31,10 +31,6 @@
             {
                 "command": "android-dev-ext.view_logcat",
                 "title": "Android: View Logcat"
-            },
-            {
-                "command": "PickAndroidProcess",
-                "title": "Android: Attach to process"
             }
         ],
         "breakpoints": [

--- a/src/adbclient.js
+++ b/src/adbclient.js
@@ -196,7 +196,7 @@ class ADBClient {
     /**
      * Starts the Logcat monitor.
      * Logcat lines are passed back via onlog callback. If the device disconnects, onclose is called.
-     * @param {{onlog:(e)=>void, onclose:()=>void}} o 
+     * @param {{onlog:(e)=>void, onclose:(err)=>void}} o 
      */
     async startLogcatMonitor(o) {
         // onlog:function(e)
@@ -217,9 +217,9 @@ class ADBClient {
             // read the next data from ADB
             let next_data;
             try{
-                next_data = await this.adbsocket.read_stdout(null);
+                next_data = await this.adbsocket.read_stdout();
             } catch(e) {
-                o.onclose();
+                o.onclose(e);
                 return;
             }
             logcatbuffer = Buffer.concat([logcatbuffer, next_data]);

--- a/src/debugMain.js
+++ b/src/debugMain.js
@@ -270,7 +270,6 @@ class AndroidDebugSession extends DebugSession {
         try {
             x = JSON.parse(`${obj}`);
         } catch {
-            return null;
         }
         if (typeof x === 'number') {
             pid = x;
@@ -281,7 +280,8 @@ class AndroidDebugSession extends DebugSession {
                 return null;
             }
         }
-        if (typeof pid !== "number") {
+        if (typeof pid !== "number" || (pid < 0)) {
+            this.LOG(`Attach failed: "processId" property in launch.json is not valid`);
             return null;
         }
         return {
@@ -299,7 +299,7 @@ class AndroidDebugSession extends DebugSession {
         D(`Attach: ${JSON.stringify(args)}`);
 
         if (!args.processId) {
-            this.LOG(`Missing "processId" property in launch.json`);
+            this.LOG(`Attach failed: Missing "processId" property in launch.json`);
             this.sendEvent(new TerminatedEvent(false));
             return;
         }

--- a/src/debugger-types.js
+++ b/src/debugger-types.js
@@ -81,10 +81,10 @@ class DebugSession {
         this.classPrepareFilters = new Set();
 
         /**
-         * The set of class signatures already prepared
+         * The set of class signatures loaded by the runtime
          * @type {Set<string>}
          */
-        this.preparedClasses = new Set();
+        this.loadedClasses = new Set();
 
         /**
          * Enabled step JDWP IDs for each thread

--- a/src/jdwp.js
+++ b/src/jdwp.js
@@ -1534,7 +1534,7 @@ class JDWP {
 					const res = [];
 					let arrlen = DataCoder.decodeInt(o);
 					while (--arrlen >= 0) {
-						res.push(DataCoder.decodeList(o, [{reftype:'reftype'},{typeid:'tref'},{type:'signature'},{genericSignature:'string'},{status:'status'}]));
+						res.push(DataCoder.decodeList(o, [{reftype:'reftype'},{typeid:'tref'},{signature:'string'},{genericSignature:'string'},{status:'status'}]));
 					}
 					return res;
 				}

--- a/src/process-attach.js
+++ b/src/process-attach.js
@@ -1,0 +1,102 @@
+const os = require('os');
+const { ADBClient } = require('./adbclient');
+
+/**
+ * @param {import('vscode')} vscode 
+ * @param {{serial:string}[]} devices 
+ */
+async function showDevicePicker(vscode, devices) {
+    const prefix = 'Attach: Device ';
+    const menu_options = devices.map(d => prefix + d.serial);
+    let chosen_option = await vscode.window.showQuickPick(menu_options);
+    if (!chosen_option) {
+        return; // user cancelled
+    }
+    chosen_option = chosen_option.slice(prefix.length);
+    const found = devices.find(d => d.serial === chosen_option);
+    if (!found) {
+        vscode.window.showInformationMessage('Attach failed. The device is disconnected.');
+        return null;
+    }
+    return found;
+}
+
+/**
+ * @param {import('vscode')} vscode 
+ * @param {number[]} pids 
+ */
+async function showPIDPicker(vscode, pids) {
+    const prefix = 'Android attach: ';
+    const menu_options = pids.sort((a,b) => a-b).map(pid => `${prefix}${pid}`);
+    let chosen_option = await vscode.window.showQuickPick(menu_options);
+    if (!chosen_option) {
+        return null; // user cancelled
+    }
+    const pid = chosen_option.slice(prefix.length);
+    return parseInt(pid, 10);
+}
+
+/**
+ * @param {import('vscode')} vscode 
+ */
+async function selectAndroidProcessID(vscode) {
+    const res = {
+        /** @type {string|'ok'|'cancelled'|'failed'} */
+        status: 'failed',
+        pid: 0,
+        serial: '',
+    }
+    const err = await new ADBClient().test_adb_connection()
+    if (err) {
+        vscode.window.showInformationMessage('Attach failed. ADB is not running');
+        return res;
+    }
+    const devices = await new ADBClient().list_devices();
+    let device;
+    switch(devices.length) {
+        case 0: 
+            vscode.window.showInformationMessage('Attach failed. No Android devices are connected');
+            return res;
+        case 1:
+            device = devices[0]; // only one device - just use it
+            break;
+        default:
+            device = await showDevicePicker(vscode, devices);
+            if (!device) {
+                // user cancelled picker
+                res.status = 'cancelled';
+                return res;
+            }
+            break;
+    }
+
+    let pids = await new ADBClient(device.serial).jdwp_list(5000);
+    if (pids.length === 0) {
+        vscode.window.showInformationMessage(
+            'Attach failed. No debuggable processes are running on the device.'
+            + `${os.EOL}${os.EOL}`
+            + `To allow a debugger to attach, the app must have the "android:debuggable=true" attribute present in AndroidManifest.xml and be running on the device.`
+            + `${os.EOL}`
+            + `See https://developer.android.com/guide/topics/manifest/application-element#debug`
+        );
+        return res;
+    }
+
+    // always show the pid picker - even if there's only one
+    const pid = await showPIDPicker(vscode, pids);
+    if (pid === null) {
+        // user cancelled picker
+        res.status = 'cancelled';
+        return res;
+    }
+
+    res.pid = pid;
+    res.serial = device.serial;
+    res.status = 'ok';
+
+    return res;
+}
+    
+module.exports = {
+    selectAndroidProcessID,
+}

--- a/src/process-attach.js
+++ b/src/process-attach.js
@@ -29,11 +29,8 @@ async function showDevicePicker(vscode, devices) {
  * @param {{pid:number,name:string}[]} pids 
  */
 async function showPIDPicker(vscode, pids) {
-    // sort by name, then by PID
-    const sorted_pids = pids.slice().sort((a,b) => {
-        const cmp = a.name.localeCompare(b.name, undefined, {sensitivity:'base'});
-        return cmp || (a.pid - b.pid);
-    });
+    // sort by PID (the user can type the package name to search)
+    const sorted_pids = pids.slice().sort((a,b) => a.pid - b.pid);
 
     /** @type {import('vscode').QuickPickItem[]} */
     const device_pick_items = sorted_pids

--- a/src/sockets/adbsocket.js
+++ b/src/sockets/adbsocket.js
@@ -78,7 +78,8 @@ class ADBSocket extends AndroidSocket {
      */
     async cmd_and_read_stdout(command, timeout_ms, until_closed) {
         await this.cmd_and_status(command);
-        return this.read_stdout('latin1', timeout_ms, until_closed);
+        const buf = await this.read_stdout(timeout_ms, until_closed);
+        return buf.toString('latin1');
     }
 
     /**

--- a/src/sockets/adbsocket.js
+++ b/src/sockets/adbsocket.js
@@ -74,10 +74,11 @@ class ADBSocket extends AndroidSocket {
      * Sends an ADB command, checks the returned status and then reads raw data from the socket
      * @param {string} command 
      * @param {number} timeout_ms
+     * @param {boolean} [until_closed]
      */
-    async cmd_and_read_stdout(command, timeout_ms) {
+    async cmd_and_read_stdout(command, timeout_ms, until_closed) {
         await this.cmd_and_status(command);
-        return this.read_stdout('latin1', timeout_ms);
+        return this.read_stdout('latin1', timeout_ms, until_closed);
     }
 
     /**

--- a/src/sockets/adbsocket.js
+++ b/src/sockets/adbsocket.js
@@ -73,10 +73,11 @@ class ADBSocket extends AndroidSocket {
     /**
      * Sends an ADB command, checks the returned status and then reads raw data from the socket
      * @param {string} command 
+     * @param {number} timeout_ms
      */
-    async cmd_and_read_stdout(command) {
+    async cmd_and_read_stdout(command, timeout_ms) {
         await this.cmd_and_status(command);
-        return this.read_stdout();
+        return this.read_stdout('latin1', timeout_ms);
     }
 
     /**

--- a/src/sockets/androidsocket.js
+++ b/src/sockets/androidsocket.js
@@ -138,20 +138,26 @@ class AndroidSocket extends EventEmitter {
         return this.read_bytes(len.readUInt32LE(0), format);
     }
 
-    async read_stdout(encoding = 'latin1', timeout_ms, until_closed) {
-        let s = await this.read_bytes(undefined, null, timeout_ms);
+    /**
+     * 
+     * @param {number} [timeout_ms] 
+     * @param {boolean} [until_closed] 
+     * @returns {Promise<Buffer>}
+     */
+    async read_stdout(timeout_ms, until_closed) {
+        let buf = await this.read_bytes(undefined, null, timeout_ms);
         if (!until_closed) {
-            return s.toString(encoding);
+            return buf;
         }
-        const parts = [s];
+        const parts = [buf];
         try {
             for (;;) {
-                s = await this.read_bytes(undefined, null);
-                parts.push(s);
+                buf = await this.read_bytes(undefined, null);
+                parts.push(buf);
             }
         } catch {
         }
-        return Buffer.concat(parts).toString(encoding);
+        return Buffer.concat(parts);
     }
 
     /**

--- a/src/sockets/androidsocket.js
+++ b/src/sockets/androidsocket.js
@@ -138,8 +138,20 @@ class AndroidSocket extends EventEmitter {
         return this.read_bytes(len.readUInt32LE(0), format);
     }
 
-    read_stdout(format = 'latin1', timeout_ms) {
-        return this.read_bytes(undefined, format, timeout_ms);
+    async read_stdout(encoding = 'latin1', timeout_ms, until_closed) {
+        let s = await this.read_bytes(undefined, null, timeout_ms);
+        if (!until_closed) {
+            return s.toString(encoding);
+        }
+        const parts = [s];
+        try {
+            for (;;) {
+                s = await this.read_bytes(undefined, null);
+                parts.push(s);
+            }
+        } catch {
+        }
+        return Buffer.concat(parts).toString(encoding);
     }
 
     /**

--- a/src/sockets/androidsocket.js
+++ b/src/sockets/androidsocket.js
@@ -64,8 +64,9 @@ class AndroidSocket extends EventEmitter {
      * 
      * @param {number|'length+data'|undefined} length 
      * @param {string} [format] 
+     * @param {number} [timeout_ms]
      */
-    async read_bytes(length, format) {
+    async read_bytes(length, format, timeout_ms) {
         //D(`reading ${length} bytes`);
         let actual_length = length;
         if (typeof actual_length === 'undefined') {
@@ -95,25 +96,40 @@ class AndroidSocket extends EventEmitter {
             return Promise.resolve(data);
         }
         // wait for the socket to update and then retry the read
-        await this.wait_for_socket_data();
+        await this.wait_for_socket_data(timeout_ms);
         return this.read_bytes(length, format);
     }
 
-    wait_for_socket_data() {
+    /**
+     * 
+     * @param {number} [timeout_ms] 
+     */
+    wait_for_socket_data(timeout_ms) {
         return new Promise((resolve, reject) => {
-            let done = 0;
+            let done = 0, timer = null;
             let onDataChanged = () => {
                 if ((done += 1) !== 1) return;
                 this.off('socket-ended', onSocketEnded);
+                clearTimeout(timer);
                 resolve();
             }
             let onSocketEnded = () => {
                 if ((done += 1) !== 1) return;
                 this.off('data-changed', onDataChanged);
+                clearTimeout(timer);
                 reject(new Error(`${this.which} socket read failed. Socket closed.`));
+            }
+            let onTimerExpired = () => {
+                if ((done += 1) !== 1) return;
+                this.off('socket-ended', onSocketEnded);
+                this.off('data-changed', onDataChanged);
+                reject(new Error(`${this.which} socket read failed. Read timeout.`));
             }
             this.once('data-changed', onDataChanged);
             this.once('socket-ended', onSocketEnded);
+            if (typeof timeout_ms === 'number' && timeout_ms >= 0) {
+                timer = setTimeout(onTimerExpired, timeout_ms);
+            }
         });
     }
 
@@ -122,8 +138,8 @@ class AndroidSocket extends EventEmitter {
         return this.read_bytes(len.readUInt32LE(0), format);
     }
 
-    read_stdout(format = 'latin1') {
-        return this.read_bytes(undefined, format);
+    read_stdout(format = 'latin1', timeout_ms) {
+        return this.read_bytes(undefined, format, timeout_ms);
     }
 
     /**
@@ -134,6 +150,7 @@ class AndroidSocket extends EventEmitter {
         return new Promise((resolve, reject) => {
             this.check_socket_active('write');
             try {
+                // @ts-ignore
                 const flushed = this.socket.write(bytes, () => {
                     flushed ? resolve() : this.socket.once('drain', resolve);
                 });

--- a/src/utils/android.js
+++ b/src/utils/android.js
@@ -1,0 +1,87 @@
+const fs = require('fs');
+const path = require('path');
+
+const { ADBClient } = require('../adbclient');
+const ADBSocket = require('../sockets/adbsocket');
+const { LOG } = require('../utils/print');
+
+function getAndroidSDKFolder() {
+    // ANDROID_HOME is deprecated
+    return process.env.ANDROID_HOME || process.env.ANDROID_SDK;
+}
+
+/**
+ * @param {string} api_level 
+ * @param {boolean} check_is_dir
+ */
+function getAndroidSourcesFolder(api_level, check_is_dir) {
+    const android_sdk = getAndroidSDKFolder();
+    if (!android_sdk) {
+        return null;
+    }
+    const sources_path = path.join(android_sdk,'sources',`android-${api_level}`);
+    if (check_is_dir) {
+        try {
+            const stat = fs.statSync(sources_path);
+            if (!stat || !stat.isDirectory()) {
+                return null;
+            }
+        } catch {
+            return null;
+        }
+    }
+    return sources_path;
+}
+
+function getADBPathName() {
+    const android_sdk = getAndroidSDKFolder();
+    if (!android_sdk) {
+        return '';
+    }
+    return path.join(android_sdk, 'platform-tools', /^win/.test(process.platform)?'adb.exe':'adb');    
+}
+
+/**
+ * @param {number} port 
+ */
+function startADBServer(port) {
+    if (typeof port !== 'number' || port <= 0 || port >= 65536) {
+        return false;
+    }
+    
+    const adb_exe_path = getADBPathName();
+    if (!adb_exe_path) {
+        return false;
+    }
+    const adb_start_server_args = ['-P',`${port}`,'start-server'];
+    try {
+        LOG([adb_exe_path, ...adb_start_server_args].join(' '));
+        const stdout = require('child_process').execFileSync(adb_exe_path, adb_start_server_args, {
+            cwd: getAndroidSDKFolder(),
+            encoding:'utf8',
+        });
+        LOG(stdout);
+        return true;
+    } catch (ex) {} // if we fail, it doesn't matter - the device query will fail and the user will have to work it out themselves
+    return false
+}
+
+/**
+ * @param {boolean} auto_start 
+ */
+async function checkADBStarted(auto_start) {
+    const err = await new ADBClient().test_adb_connection();
+    // if adb is not running, see if we can start it ourselves using ANDROID_HOME (and a sensible port number)
+    if (err && auto_start) {
+        return startADBServer(ADBSocket.ADBPort);
+    }
+    return !err;
+}
+
+module.exports = {
+    checkADBStarted,
+    getADBPathName,
+    getAndroidSDKFolder,
+    getAndroidSourcesFolder,
+    startADBServer,
+}

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -1,0 +1,55 @@
+const { ADBClient } = require('../adbclient');
+
+/**
+ * @param {import('vscode')} vscode 
+ * @param {{serial:string}[]} devices 
+ */
+async function showDevicePicker(vscode, devices) {
+    const sorted_devices = devices.slice().sort((a,b) => a.serial.localeCompare(b.serial, undefined, {sensitivity: 'base'}));
+
+    /** @type {import('vscode').QuickPickItem[]} */
+    const quick_pick_items = sorted_devices
+        .map(device => ({
+            label: `${device.serial}`,
+        }));
+
+    /** @type {import('vscode').QuickPickOptions} */
+    const quick_pick_options = {
+        canPickMany: false,
+        placeHolder: 'Choose an Android device',
+    };
+
+    const chosen_option = await vscode.window.showQuickPick(quick_pick_items, quick_pick_options);
+    return sorted_devices[quick_pick_items.indexOf(chosen_option)] || null;
+}
+
+/**
+ * 
+ * @param {import('vscode')} vscode 
+ * @param {'Attach'|'Logcat display'} action 
+ */
+async function selectTargetDevice(vscode, action) {
+    const devices = await new ADBClient().list_devices();
+    let device;
+    switch(devices.length) {
+        case 0: 
+            vscode.window.showWarningMessage(`${action} failed. No Android devices are connected.`);
+            return null;
+        case 1:
+            return devices[0]; // only one device - just use it
+    }
+    device = await showDevicePicker(vscode, devices);
+    // the user might take a while to choose the device, so once
+    // chosen, recheck it exists
+    const current_devices = await new ADBClient().list_devices();
+    if (!current_devices.find(d => d.serial === device.serial)) {
+        vscode.window.showInformationMessage(`${action} failed. The target device is disconnected`);
+        return null;
+    }
+    return device;
+}
+
+module.exports = {
+    selectTargetDevice,
+    showDevicePicker,
+}

--- a/src/utils/print.js
+++ b/src/utils/print.js
@@ -35,6 +35,23 @@ function W(...args) {
 	callMessagePrintCallbacks(args);
 }
 
+let printLogToClient;
+function initLogToClient(fn) {
+	printLogToClient = fn;
+}
+
+/**
+ * Print a log message
+ * @param {*} msg 
+ */
+function LOG(msg) {
+	if (printLogToClient) {
+		printLogToClient(msg);
+	} else {
+		D(msg);
+	}
+}
+
 /**
  * Adds a callback to be called when any message is output
  * @param {Function} cb 
@@ -45,7 +62,9 @@ function onMessagePrint(cb) {
 
 module.exports = {
     D,
-    E,
+	E,
+	initLogToClient,
+	LOG,
     W,
     onMessagePrint,
 }


### PR DESCRIPTION
Add new launch configuration to allow the debugger to connect to debuggable apps and Java processes running on the device.

The default configuration uses a processId value of `"${command:PickAndroidProcess}"` to automicatically invoke a new extension command to list debuggable processes running on the connected device.

- The attach launch config requires the `appSrcRoot` in order to identify breakpoint locations.
- To ensure all breakpoints are loaded after attaching, a list of all currently loaded classes is now retrieved upon connection.
- VSCode quick-pick lists are used to select which device (if there's more than one) and which process should be attached to.
- The `adb jdwp` command never terminates - we use a timeout value to limit how long we search for debuggable processes.
- Retrieving the package names of the PIDs uses a shell for loop which requires multiple socket reads to obtain all of the output. A new `untilclosed` flag has been added to the socket functions to allow this, which keeps reading from the socket until the other side closes it.