### PR TITLE
Support for device picker during launch

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -4,6 +4,7 @@ const vscode = require('vscode');
 const { AndroidContentProvider } = require('./src/contentprovider');
 const { openLogcatWindow } = require('./src/logcat');
 const { selectAndroidProcessID } = require('./src/process-attach');
+const { selectTargetDevice } = require('./src/utils/device');
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -17,6 +18,12 @@ function activate(context) {
         // add the view logcat handler
         vscode.commands.registerCommand('android-dev-ext.view_logcat', () => {
             openLogcatWindow(vscode);
+        }),
+        // add the device picker handler - used to choose a target device
+        vscode.commands.registerCommand('PickAndroidDevice', async () => {
+            const device = await selectTargetDevice(vscode, "Launch", { alwaysShow:true });
+            // the debugger requires a string value to be returned
+            return JSON.stringify(device);
         }),
         // add the process picker handler - used to choose a PID to attach to
         vscode.commands.registerCommand('PickAndroidProcess', async () => {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     },
     "activationEvents": [
         "onCommand:android-dev-ext.view_logcat",
+        "onCommand:PickAndroidDevice",
         "onCommand:PickAndroidProcess"
     ],
     "repository": {
@@ -121,7 +122,7 @@
                             "targetDevice": {
                                 "type": "string",
                                 "description": "Target Device ID (as indicated by 'adb devices'). Use this to specify which device is used for deployment when multiple devices are connected.",
-                                "default": ""
+                                "default": "${command:PickAndroidDevice}"
                             },
                             "trace": {
                                 "type": "boolean",
@@ -155,7 +156,7 @@
                             "targetDevice": {
                                 "type": "string",
                                 "description": "Target Device ID (as indicated by 'adb devices'). Use this to specify which device is used when multiple devices are connected.",
-                                "default": ""
+                                "default": "${command:PickAndroidDevice}"
                             },
                             "trace": {
                                 "type": "boolean",

--- a/src/debugger-types.js
+++ b/src/debugger-types.js
@@ -9,7 +9,7 @@ class BuildInfo {
      * @param {string} pkgname 
      * @param {Map<string,PackageInfo>} packages 
      * @param {string} launchActivity 
-     * @param {string[]} amCommandArgs custom arguments passed to `am start`
+     * @param {string[]} [amCommandArgs] custom arguments passed to `am start`
      */
     constructor(pkgname, packages, launchActivity, amCommandArgs) {
         this.pkgname = pkgname;


### PR DESCRIPTION
Adds support for displaying a quick-pick list of connected devices for the user to choose from.

Enabled by setting `"targetDevice": "${command:PickAndroidDevice}"` in the launch options.