### PR TITLE
Version 1.1 improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Add a `preLaunchTask` item to the launch configuration:
             "request": "launch",
             "name": "App Build & Launch",
             "preLaunchTask": "run gradle",
+            ...
         }
     ]
 }
@@ -127,7 +128,22 @@ Add a new task to run the build command:
             "label": "run gradle",
             "type": "shell",
             "command": "${workspaceFolder}/gradlew",
-            "args": ["assembleDebug"]
+            "args": [
+                "assembleDebug"
+            ],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ The following settings are used to configure the debugger:
                 // mutually exclusive with "amStartArgs".
                 "launchActivity": ".MainActivity",
 
+                // Time in milliseconds to wait after launching an app before attempting to attach
+                // the debugger. Default: 1000ms
+                "postLaunchPause": 1000,
+
                 // Set to true to output debugging logs for diagnostics.
                 "trace": false
             }

--- a/package.json
+++ b/package.json
@@ -114,6 +114,11 @@
                                     "-r"
                                 ]
                             },
+                            "postLaunchPause": {
+                                "type": "number",
+                                "description": "Time in milliseconds to wait after launching an app before attempting to attach the debugger. Default: 1000",
+                                "default": 1000
+                            },
                             "staleBuild": {
                                 "type": "string",
                                 "description": "Launch behaviour if source files have been saved after the APK was built. One of: [\"ignore\" \"warn\" \"stop\"]. Default: \"warn\"",

--- a/src/apk-decoder.js
+++ b/src/apk-decoder.js
@@ -107,7 +107,7 @@ function decode_spec_value(o, key, value, buf, idx, main) {
         case /^align:\d+$/.test(value): {
             // used for arbitrary padding to a specified alignment
             const align = parseInt(value.split(':')[1], 10);
-            byteLength = align - (idx % align);
+            byteLength = idx - (Math.trunc(idx / align) * align);
             o[key] = buf.slice(idx, idx + byteLength);
             break;
         }

--- a/src/apk-file-info.js
+++ b/src/apk-file-info.js
@@ -104,8 +104,7 @@ class APKFileInfo {
  *   2. The decoded manifest from the APK
  *   3. The AndroidManifest.xml file from the root of the source tree.
  */
-async function getAndroidManifestXml(args) {
-    const {manifestFile, apkFile, appSrcRoot} = args;
+async function getAndroidManifestXml({manifestFile, apkFile, appSrcRoot}) {
     let manifest;
 
     // a value from the manifestFile overrides the default manifest extraction
@@ -121,7 +120,7 @@ async function getAndroidManifestXml(args) {
         manifest = await extractManifestFromAPK(apkFile);
     } catch(err) {
         // if we fail to get manifest from the APK, revert to the source file version
-        D(`Reading source manifest from ${appSrcRoot}`);
+        D(`Reading source manifest from ${appSrcRoot} (${err.message})`);
         manifest = await readFile(path.join(appSrcRoot, 'AndroidManifest.xml'), 'utf8');
     }
     return manifest;

--- a/src/debugMain.js
+++ b/src/debugMain.js
@@ -382,7 +382,12 @@ class AndroidDebugSession extends DebugSession {
             // try and determine the relevant path for the API sources (based upon the API level of the connected device)
             await this.configureAPISourcePath();
 
-            const build = new BuildInfo(null, new Map(this.src_packages.packages), null);
+            const build = new BuildInfo(
+                null,
+                new Map(this.src_packages.packages),
+                null,
+                null,
+                args.postLaunchPause);
             this.LOG(`Attaching to pid ${processId} on device ${this._device.serial} [API:${this.device_api_level||'?'}]`);
 
             // try and attach to the specified pid
@@ -512,7 +517,7 @@ class AndroidDebugSession extends DebugSession {
             await this.configureAPISourcePath();
 
             // launch the app
-            await this.startLaunchActivity(args.launchActivity);
+            await this.startLaunchActivity(args.launchActivity, args.postLaunchPause);
 
             this.debuggerAttached = true;
 
@@ -564,7 +569,12 @@ class AndroidDebugSession extends DebugSession {
         }
     }
 
-    async startLaunchActivity(launchActivity) {
+    /**
+     * 
+     * @param {string} launchActivity 
+     * @param {number} postLaunchPause 
+     */
+    async startLaunchActivity(launchActivity, postLaunchPause) {
         if (!launchActivity) {
             // we're allowed no launchActivity if we have a custom am start command
             if (!this.am_start_args) {
@@ -574,7 +584,12 @@ class AndroidDebugSession extends DebugSession {
             }
         }
 
-        const build = new BuildInfo(this.apk_file_info.manifest.package, new Map(this.src_packages.packages), launchActivity, this.am_start_args);
+        const build = new BuildInfo(
+            this.apk_file_info.manifest.package,
+            new Map(this.src_packages.packages),
+            launchActivity,
+            this.am_start_args,
+            postLaunchPause);
 
         this.LOG(`Launching on device ${this._device.serial} [API:${this.device_api_level||'?'}]`);
         if (this.am_start_args) {

--- a/src/debugMain.js
+++ b/src/debugMain.js
@@ -77,7 +77,7 @@ class AndroidDebugSession extends DebugSession {
         this._android_sources_path = '';
 
         // number of call stack entries to display above the project source
-        this.callStackDisplaySize = 1;
+        this.callStackDisplaySize = 0;
 
         /**
          * the fifo queue of evaluations (watches, hover, etc)

--- a/src/debugMain.js
+++ b/src/debugMain.js
@@ -251,10 +251,11 @@ class AndroidDebugSession extends DebugSession {
         // configure the thread names
         threadinfos.forEach(threadinfo => {
             const thread = this.getThread(threadinfo.threadid);
-            if (thread.name === null) {
+            if (typeof thread.name !== 'string') {
                 thread.name = threadinfo.name;
             } else if (thread.name !== threadinfo.name) {
                 // give the thread a new id for VS code
+                // - note: this will invalidate all current variable references for this thread
                 delete this._threads[thread.vscode_threadid];
                 thread.allocateNewThreadID();
                 this._threads[thread.vscode_threadid] = thread;

--- a/src/debugger-types.js
+++ b/src/debugger-types.js
@@ -688,7 +688,7 @@ class DebuggerTypeInfo {
         // otherwise, leave super undefined to be updated later
         if (info.reftype.string !== 'class' || type.signature[0] !== 'L' || type.signature === JavaType.Object.signature) {
             if (info.reftype.string !== 'array') {
-                /** @type {JavaType} */
+                /** @type {JavaClassType} */
                 this.super = null;
             }
         }

--- a/src/debugger-types.js
+++ b/src/debugger-types.js
@@ -9,9 +9,10 @@ class BuildInfo {
      * @param {string} pkgname 
      * @param {Map<string,PackageInfo>} packages 
      * @param {string} launchActivity 
-     * @param {string[]} [amCommandArgs] custom arguments passed to `am start`
+     * @param {string[]} amCommandArgs custom arguments passed to `am start`
+     * @param {number} postLaunchPause amount of time (in ms) to wait after launch before we attempt a debugger connection
      */
-    constructor(pkgname, packages, launchActivity, amCommandArgs) {
+    constructor(pkgname, packages, launchActivity, amCommandArgs, postLaunchPause) {
         this.pkgname = pkgname;
         this.packages = packages;
         this.launchActivity = launchActivity;
@@ -24,10 +25,10 @@ class BuildInfo {
             `-n ${pkgname}/${launchActivity}`,
         ];
         /** 
-         * the amount of time to wait after 'am start ...' is invoked.
+         * the amount of time (in millis) to wait after 'am start ...' is invoked.
          * We need this because invoking JDWP too soon causes a hang.
         */
-        this.postLaunchPause = 1000;
+        this.postLaunchPause = ((typeof postLaunchPause === 'number') && (postLaunchPause >= 0)) ? postLaunchPause : 1000;
     }
 }
 

--- a/src/debugger-types.js
+++ b/src/debugger-types.js
@@ -4,17 +4,25 @@ const { PackageInfo } = require('./package-searcher');
 const { splitSourcePath } = require('./utils/source-file');
 
 class BuildInfo {
-
     /**
-     * @param {string} pkgname 
      * @param {Map<string,PackageInfo>} packages 
+     */
+    constructor(packages) {
+        this.packages = packages;
+    }
+}
+
+class LaunchBuildInfo extends BuildInfo {
+    /**
+     * @param {Map<string,PackageInfo>} packages 
+     * @param {string} pkgname 
      * @param {string} launchActivity 
      * @param {string[]} amCommandArgs custom arguments passed to `am start`
      * @param {number} postLaunchPause amount of time (in ms) to wait after launch before we attempt a debugger connection
      */
-    constructor(pkgname, packages, launchActivity, amCommandArgs, postLaunchPause) {
+    constructor(packages, pkgname, launchActivity, amCommandArgs, postLaunchPause) {
+        super(packages);
         this.pkgname = pkgname;
-        this.packages = packages;
         this.launchActivity = launchActivity;
         /** the arguments passed to `am start` */
         this.startCommandArgs = amCommandArgs || [
@@ -29,6 +37,15 @@ class BuildInfo {
          * We need this because invoking JDWP too soon causes a hang.
         */
         this.postLaunchPause = ((typeof postLaunchPause === 'number') && (postLaunchPause >= 0)) ? postLaunchPause : 1000;
+    }
+}
+
+class AttachBuildInfo extends BuildInfo {
+    /**
+     * @param {Map<string,PackageInfo>} packages 
+     */
+    constructor(packages) {
+        super(packages);
     }
 }
 
@@ -748,9 +765,9 @@ class VariableValue {
 }
 
 module.exports = {
+    AttachBuildInfo,
     BreakpointLocation,
     BreakpointOptions,
-    BuildInfo,
     DebuggerBreakpoint,
     DebuggerException,
     DebuggerFrameInfo,
@@ -758,6 +775,7 @@ module.exports = {
     DebuggerTypeInfo,
     DebugSession,
     DebuggerValue,
+    LaunchBuildInfo,
     LiteralValue,
     JavaBreakpointEvent,
     JavaExceptionEvent,

--- a/src/debugger.js
+++ b/src/debugger.js
@@ -127,9 +127,9 @@ class Debugger extends EventEmitter {
     /**
      * @param {string} deviceid Device ID to connect to
      * @param {string[]} launch_cmd_args Array of arguments to pass to 'am start'
-     * @param {number} [post_launch_pause] amount to time to wait after each launch attempt
+     * @param {number} post_launch_pause amount of time (in ms) to wait after each launch attempt
      */
-    static async runApp(deviceid, launch_cmd_args, post_launch_pause = 1000) {
+    static async runApp(deviceid, launch_cmd_args, post_launch_pause) {
         // older (<3) versions of Android only allow target components to be specified with -n
         const shell_cmd = {
             command: `am start ${launch_cmd_args.join(' ')}`,

--- a/src/debugger.js
+++ b/src/debugger.js
@@ -8,9 +8,9 @@ const { D } = require('./utils/print');
 const { sleep } = require('./utils/thread');
 const { decodeJavaStringLiteral } = require('./utils/char-decode');
 const {
+    AttachBuildInfo,
     BreakpointLocation,
     BreakpointOptions,
-    BuildInfo,
     DebuggerBreakpoint,
     DebuggerFrameInfo,
     DebuggerMethodInfo,
@@ -24,6 +24,7 @@ const {
     JavaTaggedValue,
     JavaThreadInfo,
     JavaType,
+    LaunchBuildInfo,
     MethodInvokeArgs,
     SourceLocation,
     TypeNotAvailable,
@@ -71,7 +72,7 @@ class Debugger extends EventEmitter {
     };
 
     /**
-     * @param {BuildInfo} build
+     * @param {LaunchBuildInfo} build
      * @param {string} deviceid
      */
     async startDebugSession(build, deviceid) {
@@ -111,7 +112,7 @@ class Debugger extends EventEmitter {
     }
 
     /**
-     * @param {BuildInfo} build
+     * @param {AttachBuildInfo} build
      * @param {number} pid process ID to connect to
      * @param {string} deviceid device ID to connect to
      */
@@ -318,7 +319,9 @@ class Debugger extends EventEmitter {
         if (!this.session) {
             return;
         }
-        return Debugger.forceStopApp(this.session.deviceid, this.session.build.pkgname);
+        if (this.session.build instanceof LaunchBuildInfo) {
+            return Debugger.forceStopApp(this.session.deviceid, this.session.build.pkgname);
+        }
     }
 
     /**

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -88,10 +88,16 @@ class UnaryOpExpression extends ParsedExpression {
 }
 
 class TernaryExpression extends ParsedExpression {
+
+    /**
+     * @param {ParsedExpression} condition 
+     */
     constructor(condition) {
         super();
         this.condition = condition;
+        /** @type {ParsedExpression} */
         this.ternary_true = null;
+        /** @type {ParsedExpression} */
         this.ternary_false = null;
     }
 }
@@ -101,17 +107,24 @@ class QualifierExpression extends ParsedExpression {
 }
 
 class ArrayIndexExpression extends QualifierExpression {
-    constructor(e) {
+    /**
+     * @param {ParsedExpression} index_expression 
+     */
+    constructor(index_expression) {
         super();
-        this.indexExpression = e;
+        this.indexExpression = index_expression;
     }
 }
 
 class MethodCallExpression extends QualifierExpression {
+    /** @type {ParsedExpression[]} */
     arguments = [];
 }
 
 class MemberExpression extends QualifierExpression {
+    /**
+     * @param {string} name 
+     */
     constructor(name) {
         super();
         this.name = name;

--- a/src/index.d.js
+++ b/src/index.d.js
@@ -108,6 +108,7 @@
  * @typedef {number} JDWPRequestID
  * @typedef {JDWPRequestID} StepID
  * @typedef {'caught'|'uncaught'|'both'} ExceptionBreakMode
+ * @typedef {'ignore'|'warn'|'stop'} StaleBuildSetting
  * 
  */
 

--- a/src/stack-frame.js
+++ b/src/stack-frame.js
@@ -137,7 +137,7 @@ class DebuggerStackFrame extends VariableManager {
     }
 
     async getObjectFields(varinfo) {
-        const supertype = await this.dbgr.getSuperType(varinfo.objvar);
+        const supertype = await this.dbgr.getSuperType(varinfo.objvar.type.signature);
         const fields = await this.dbgr.getFieldValues(varinfo.objvar);
         // add an extra msg field for exceptions
         if (varinfo.exception) {


### PR DESCRIPTION
Small fixes and improvements for version 1.1:

- Bug fix: binary XML decoding failed when padding field is zero-length
- During app launch, the process name is now checked to ensure the debugger is connecting to the  correct pid.
- The post-launch-pause value is now user-configurable.
- Evaluations are now added to a queue before being run sequentially
- Call stack is now shown in full by default.
- Identifier expressions are now automatically checked against fields in the 'this' context.
