### PR TITLE
Add support for ADB server environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### version 1.3.0
+* Support `ADB_SERVER_SOCKET`, `ANDROID_ADB_SERVER_ADDRESS` & `ANDROID_ADB_SERVER_PORT` env vars when connecting to ADB.
+* Replace `adbPort` configuration option with a new `adbSocket` value to allow ADB server host to be overidden. (`adbPort` is now deprecated).
+* Allow the JDWP local port to be fixed using a new `jdwpPort` configuration option.
+
 ### version 1.2.1
 * Java Intellisense: automatically import dependencies of AndroidX libraries.
 * Debugger: Warn about open instances of Android Studio

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ The following settings are used to configure the debugger:
                 // Fully qualified path to the built APK (Android Application Package).
                 "apkFile": "${workspaceRoot}/app/build/outputs/apk/app-debug.apk",
 
-                // Port number to connect to the local ADB (Android Debug Bridge) instance.
-                // Default: 5037
-                "adbPort": 5037,
+                // `host:port` configuration for connecting to the ADB (Android Debug Bridge) server instance.
+                // Default: localhost:5037
+                "adbSocket": "localhost:5037",
 
                 // Automatically launch 'adb start-server' if not already started.
                 // Default: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "android-dev-ext",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -238,8 +238,7 @@
                     "launch": {
                         "required": [
                             "appSrcRoot",
-                            "apkFile",
-                            "adbPort"
+                            "apkFile"
                         ],
                         "properties": {
                             "amStartArgs": {
@@ -265,12 +264,17 @@
                             },
                             "adbPort": {
                                 "type": "integer",
-                                "description": "Port number to connect to the local ADB (Android Debug Bridge) instance. Default: 5037",
+                                "description": "Port number to connect to the local ADB (Android Debug Bridge) instance. Default: 5037\nDeprecated: Configure the 'adbSocket' property instead.",
                                 "default": 5037
+                            },
+                            "adbSocket": {
+                                "type": "string",
+                                "description": "`host : port` configuration for connecting to the ADB (Android Debug Bridge) server instance. Default: \"localhost:5037\"",
+                                "default": "localhost:5037"
                             },
                             "autoStartADB": {
                                 "type": "boolean",
-                                "description": "Automatically launch 'adb start-server' if not already started. Default: true",
+                                "description": "Automatically attempt to launch 'adb start-server' if not already started. Default: true",
                                 "default": true
                             },
                             "callStackDisplaySize": {
@@ -325,7 +329,6 @@
                     "attach": {
                         "required": [
                             "appSrcRoot",
-                            "adbPort",
                             "processId"
                         ],
                         "properties": {
@@ -336,8 +339,13 @@
                             },
                             "adbPort": {
                                 "type": "integer",
-                                "description": "Port number to connect to the local ADB (Android Debug Bridge) instance. Default: 5037",
+                                "description": "Port number to connect to the local ADB (Android Debug Bridge) instance. Default: 5037\nDeprecated: Configure the 'adbSocket' property instead.",
                                 "default": 5037
+                            },
+                            "adbSocket": {
+                                "type": "string",
+                                "description": "`host : port` configuration for connecting to the ADB (Android Debug Bridge) server instance. Default: \"localhost:5037\"",
+                                "default": "localhost:5037"
                             },
                             "processId": {
                                 "type": "string",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "android-dev-ext",
     "displayName": "Android",
     "description": "Android debugging support for VS Code",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "publisher": "adelphes",
     "preview": true,
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -352,6 +352,11 @@
                                 "description": "`host : port` configuration for connecting to the ADB (Android Debug Bridge) server instance. Default: \"localhost:5037\"",
                                 "default": "localhost:5037"
                             },
+                            "jdwpPort": {
+                                "type": "integer",
+                                "description": "Manually specify the local port used for connecting to the on-device debugger client.\nThis can be useful if you are using port-forwarding to connect to a remote device.\nThe specified port must be available and different from the ADB socket port.\nSet to 0 for automatic (dynamic) assignment.\nDefault: 0",
+                                "default": 0
+                            },
                             "processId": {
                                 "type": "string",
                                 "description": "PID of process to attach to.\n\"${command:PickAndroidProcess}\" will display a list of debuggable PIDs to choose from during launch.",

--- a/package.json
+++ b/package.json
@@ -282,6 +282,11 @@
                                 "description": "Number of entries to display in call stack views (for locations outside of the project source). 0 shows the entire call stack. Default: 1",
                                 "default": 1
                             },
+                            "jdwpPort": {
+                                "type": "integer",
+                                "description": "Manually specify the local port used for connecting to the on-device debugger client.\nThis can be useful if you are using port-forwarding to connect to a remote device.\nThe specified port must be available and different from the ADB socket port.\nSet to 0 for automatic (dynamic) assignment.\nDefault: 0",
+                                "default": 0
+                            },
                             "launchActivity": {
                                 "type": "string",
                                 "description": "Manually specify the activity to run when the app is started.",

--- a/src/adbclient.js
+++ b/src/adbclient.js
@@ -61,6 +61,14 @@ function getADBSocketParams() {
  */
 function getIntialADBSocketParams() {
 
+    /**
+     * Retrieve a trimmed environment variable or return a blank string
+     * @param {string} name 
+     */
+    function envValue(name) {
+        return (process.env[name] || '').trim();
+    }
+
     function decode_port_string(s) {
         if (!/^\d+$/.test(s)) {
             return;
@@ -88,7 +96,7 @@ function getIntialADBSocketParams() {
     }
     
     // ADB_SERVER_SOCKET=tcp:<host>:<port>
-    const adb_server_socket_match = (process.env['ADB_SERVER_SOCKET'] || '').match(/^tcp(?::(.*))?(?::(\d+))$/);
+    const adb_server_socket_match = envValue('ADB_SERVER_SOCKET').match(/^\s*tcp(?::(.*))?(?::(\d+))\s*$/);
     if (adb_server_socket_match) {
         return {
             host: adb_server_socket_match[1] || default_host,
@@ -97,8 +105,8 @@ function getIntialADBSocketParams() {
     }
 
     return {
-        host: process.env['ANDROID_ADB_SERVER_ADDRESS'] || default_host,
-        port: decode_port_string(process.env['ANDROID_ADB_SERVER_PORT']) || default_port,
+        host: envValue('ANDROID_ADB_SERVER_ADDRESS') || default_host,
+        port: decode_port_string(envValue('ANDROID_ADB_SERVER_PORT')) || default_port,
     }
 }
 

--- a/src/adbclient.js
+++ b/src/adbclient.js
@@ -247,7 +247,10 @@ class ADBClient {
         // note that upon success, this method does not close the connection (it must be left open for
         // future commands to be sent over the jdwp socket)
         this.jdwp_socket = new JDWPSocket(o.onreply, o.ondisconnect);
-        await this.jdwp_socket.connect(o.localport)
+        // assume the 'local' port (routed to connect to the process on the device) 
+        // is set up on the same host that the adb server is running on
+        const adb_server_socket = getADBSocketParams();
+        await this.jdwp_socket.connect(o.localport, adb_server_socket.host);
         await this.jdwp_socket.start();
         return true;
     }

--- a/src/debugMain.js
+++ b/src/debugMain.js
@@ -340,7 +340,7 @@ class AndroidDebugSession extends DebugSession {
             this.trace = args.trace;
             onMessagePrint(this.LOG.bind(this));
         }
-        D(`Attach: ${JSON.stringify(args)}`);
+        D(JSON.stringify({type: 'attach', args, env:process.env}, null, ' '));
 
         if (args.targetDevice === 'null') {
             // "null" is returned from the device picker if there's an error or if the
@@ -485,7 +485,7 @@ class AndroidDebugSession extends DebugSession {
             this.trace = args.trace;
             onMessagePrint(this.LOG.bind(this));
         }
-        D(`Launch: ${JSON.stringify(args)}`);
+        D(JSON.stringify({type: 'launch', args, env:process.env}, null, ' '));
 
         if (args.targetDevice === 'null') {
             // "null" is returned from the device picker if there's an error or if the

--- a/src/debugMain.js
+++ b/src/debugMain.js
@@ -325,8 +325,11 @@ class AndroidDebugSession extends DebugSession {
 
     /**
      * @typedef AndroidAttachArguments
+     * @property {number} adbPort
+     * @property {string} adbSocket
      * @property {string} appSrcRoot
      * @property {boolean} autoStartADB
+     * @property {number} jdwpPort
      * @property {number} processId
      * @property {string} targetDevice
      * @property {boolean} trace
@@ -366,6 +369,18 @@ class AndroidDebugSession extends DebugSession {
             this.terminate_reason = "null-attachinfo";
             this.sendEvent(new TerminatedEvent(false));
             return;
+        }
+
+        // set the custom ADB host and port
+        if (typeof args.adbSocket === 'string' && args.adbSocket) {
+            ADBSocket.HostPort = args.adbSocket;
+        } else if (typeof args.adbPort === 'number' && args.adbPort >= 0 && args.adbPort <= 65535) {
+            ADBSocket.HostPort = `:${args.adbPort}`;
+        }
+
+        // set the fixed JDWP port number (if any)
+        if (typeof args.jdwpPort === 'number' && args.jdwpPort >= 0 && args.jdwpPort <= 65535) {
+            Debugger.portManager.fixedport = args.jdwpPort;
         }
 
         try {
@@ -514,7 +529,7 @@ class AndroidDebugSession extends DebugSession {
             return;
         }
 
-        // set the custom ADB host and port - this should be changed to pass it to each ADBClient instance
+        // set the custom ADB host and port
         if (typeof args.adbSocket === 'string' && args.adbSocket) {
             ADBSocket.HostPort = args.adbSocket;
         } else if (typeof args.adbPort === 'number' && args.adbPort >= 0 && args.adbPort <= 65535) {

--- a/src/debugMain.js
+++ b/src/debugMain.js
@@ -466,6 +466,7 @@ class AndroidDebugSession extends DebugSession {
      * @property {string} appSrcRoot
      * @property {boolean} autoStartADB
      * @property {number} callStackDisplaySize
+     * @property {number} jdwpPort
      * @property {string} launchActivity
      * @property {string} manifestFile
      * @property {string[]} pmInstallArgs
@@ -518,6 +519,11 @@ class AndroidDebugSession extends DebugSession {
             ADBSocket.HostPort = args.adbSocket;
         } else if (typeof args.adbPort === 'number' && args.adbPort >= 0 && args.adbPort <= 65535) {
             ADBSocket.HostPort = `:${args.adbPort}`;
+        }
+
+        // set the fixed JDWP port number (if any)
+        if (typeof args.jdwpPort === 'number' && args.jdwpPort >= 0 && args.jdwpPort <= 65535) {
+            Debugger.portManager.fixedport = args.jdwpPort;
         }
 
         try {

--- a/src/debugMain.js
+++ b/src/debugMain.js
@@ -446,10 +446,10 @@ class AndroidDebugSession extends DebugSession {
             if (/^ADB server is not running/.test(e.msg)) {
                 this.LOG('Make sure the Android SDK Platform Tools are installed and run:');
                 this.LOG('      adb start-server');
-                this.LOG('If you are running ADB on a non-default port, also make sure the adbPort value in your launch.json is correct.');
+                this.LOG('If you are running ADB using a non-default configuration, also make sure the adbSocket value in your launch.json is correct.');
             }
             if (/ADB|JDWP/.test(msg)) {
-                this.LOG('Ensure any instances of Android Studio are closed.');
+                this.LOG('Ensure any instances of Android Studio are closed and ADB is running.');
             }
             // tell the client we're done
             this.terminate_reason = `start-exception: ${msg}`;
@@ -460,6 +460,7 @@ class AndroidDebugSession extends DebugSession {
     /**
      * @typedef AndroidLaunchArguments
      * @property {number} adbPort
+     * @property {string} adbSocket
      * @property {string[]} amStartArgs 
      * @property {string} apkFile
      * @property {string} appSrcRoot
@@ -512,9 +513,11 @@ class AndroidDebugSession extends DebugSession {
             return;
         }
 
-        // set the custom ADB port - this should be changed to pass it to each ADBClient instance
-        if (typeof args.adbPort === 'number' && args.adbPort >= 0 && args.adbPort <= 65535) {
-            ADBSocket.ADBPort = args.adbPort;
+        // set the custom ADB host and port - this should be changed to pass it to each ADBClient instance
+        if (typeof args.adbSocket === 'string' && args.adbSocket) {
+            ADBSocket.HostPort = args.adbSocket;
+        } else if (typeof args.adbPort === 'number' && args.adbPort >= 0 && args.adbPort <= 65535) {
+            ADBSocket.HostPort = `:${args.adbPort}`;
         }
 
         try {

--- a/src/debugger.js
+++ b/src/debugger.js
@@ -52,9 +52,14 @@ class Debugger extends EventEmitter {
 
     static portManager = {
         portrange: { lowest: 31000, highest: 31099 },
+        fixedport: 0,
         inuseports: new Set(),
         debuggers: {},
         reserveport: function () {
+            if (this.fixedport > 0 && this.fixedport < 65536) {
+                this.inuseports.add(this.fixedport);
+                return this.fixedport;
+            }
             // choose a random port to use each time
             for (let i = 0; i < 10000; i++) {
                 const portidx = this.portrange.lowest + ((Math.random() * 100) | 0);

--- a/src/sockets/adbsocket.js
+++ b/src/sockets/adbsocket.js
@@ -7,10 +7,17 @@ const AndroidSocket = require('./androidsocket');
 class ADBSocket extends AndroidSocket {
 
     /**
-     * The port number to run ADB on.
-     * The value can be overriden by the adbPort value in each configuration.
+     * The host and port number to run ADB commands on, in 'host:port' format (host part is optional).
+     * The value can be overriden by the adbSocket (or the deprecated adbPort) value in each debug configuration.
+     * 
+     * The default host value is left blank as this is the simplest way to
+     * specify "connect to the local machine" without explicitly specifying 
+     * 'localhost' or '127.0.0.1' (which may be mapped to something else)
      */
-    static ADBPort = 5037;
+    static HostPort = `:5037`;
+    static get DefaultHostPort() {
+        return `:5037`
+    }
 
     constructor() {
         super('ADBSocket');

--- a/src/sockets/adbsocket.js
+++ b/src/sockets/adbsocket.js
@@ -25,13 +25,14 @@ class ADBSocket extends AndroidSocket {
 
     /**
      * Reads and checks the reply from an ADB command
+     * @param {string} command
      * @param {boolean} [throw_on_fail] true if the function should throw on non-OKAY status
      */
-    async read_adb_status(throw_on_fail = true) {
+    async read_adb_status(command, throw_on_fail = true) {
         // read back the status
         const status = await this.read_bytes(4, 'latin1')
         if (status !== 'OKAY' && throw_on_fail) {
-            throw new Error(`ADB command failed. Status: '${status}'`);
+            throw new Error(`ADB command '${command}' failed. Status: '${status}'`);
         }
         return status;
     }
@@ -64,7 +65,7 @@ class ADBSocket extends AndroidSocket {
      */
     async cmd_and_status(command) {
         await this.write_adb_command(command);
-        return this.read_adb_status();
+        return this.read_adb_status(command);
     }
 
     /**
@@ -111,7 +112,7 @@ class ADBSocket extends AndroidSocket {
         await this.write_bytes(done_and_mtime);
 
         // read the final status and any error message
-        const result = await this.read_adb_status(false);
+        const result = await this.read_adb_status('sync:', false);
         const failmsg = await this.read_le_length_data('latin1');
         
         // finish the transfer mode


### PR DESCRIPTION
ADB makes use of the following environment variables:

- ADB_SERVER_SOCKET
- ANDROID_ADB_SERVER_ADDRESS
- ANDROID_ADB_SERVER_PORT

These variables are used to automatically specify how ADB should connect to its server instance.  
https://android.googlesource.com/platform/system/core/+/135f4ab3dd6c14f10a7bd1b1a4f9bfcf2135acb8/adb/commandline.cpp#1552

This change adds support for automatically using these if vscode is launched with these environment variables configured.

To support more remote adb/device configurations:
- `adbPort` has been replaced with `adbSocket` to allow the adb server hostname to be specified in the debug configuration.
- `jdwpPort` has been added to allow the debugger connection port to be fixed (instead of choosing a random port on each launch).

Smaller improvements:
- If an ADB command fails, the failing command is now included in the log.
- Environment variables are printed during startup when `trace` is true.

Fixes #95 