### PR TITLE
Ignore DDM chunk commands

### DIFF
--- a/src/jdwp.js
+++ b/src/jdwp.js
@@ -99,9 +99,26 @@ class Reply {
 			return;
 		}
 	
+		if (this.errorcode === 50945) {
+			// errorcode===50945 (0xC701) refers to a DDM chunk (set 199, cmd 1) for a
+			// previous command. It's unclear why these are being sent but it appears 
+			// they're safe to ignore.
+			//
+			// see https://android.googlesource.com/platform/art/+/master/adbconnection/adbconnection.cc
+			this.decoded = {
+				empty: true,
+				errorcode: 0
+			}
+			return;
+		}
+
 		if (this.errorcode !== 0) {
 			// https://docs.oracle.com/javase/7/docs/platform/jpda/jdwp/jdwp-protocol.html#JDWP_Error
-			E(`JDWP command failed '${this.command.name}'. Error ${this.errorcode}`, this);
+			if (this.command !== undefined) {
+				E(`JDWP command failed '${this.command.name}'. Error ${this.errorcode}`, this);
+			} else {
+				E(`Unknown JDWP command with id '${this.id}' failed. Error ${this.errorcode}`, this);
+			}
 		}
 		
 		if (!this.errorcode && this.command && this.command.replydecodefn) {


### PR DESCRIPTION
Honestly, I have no idea why, but ADB occasionally returns DDM chunk chunk commands for commands for which we previously received a response. These commands are characterized by the commandset 199 (which is in the custom vendor range of 128-255) and a command of 1.

Because these responses refer to commands for which we've already received a response, the code actually blows up entirely with a (hidden) null reference exception in the error printing code (it attempts to dereference this.command which is now undefined).

This fix adds special handling for these commands, though nothing sophisticated: it just ignores them.

In addition, we fix up the error handling code so that if multiple responses for a command are received in the future, we don't blow up.