### PR TITLE
Fixed bug - amStartArgs not accepted in "launch" config

### DIFF
--- a/src/debugMain.js
+++ b/src/debugMain.js
@@ -568,7 +568,7 @@ class AndroidDebugSession extends DebugSession {
 
             // check we have something to launch - we do this again later, but it's a bit better to do it before we start device comms
             let launchActivity = args.launchActivity;
-            if (!launchActivity)
+            if (!launchActivity && !this.am_start_args)
                 if (!(launchActivity = this.apk_file_info.manifest.launcher))
                     throw new Error('No valid launch activity found in AndroidManifest.xml or launch.json');
 

--- a/src/debugMain.js
+++ b/src/debugMain.js
@@ -568,7 +568,7 @@ class AndroidDebugSession extends DebugSession {
 
             // check we have something to launch - we do this again later, but it's a bit better to do it before we start device comms
             let launchActivity = args.launchActivity;
-            if (!launchActivity && !this.am_start_args)
+            if (!launchActivity && !this.am_start_args?.length)
                 if (!(launchActivity = this.apk_file_info.manifest.launcher))
                     throw new Error('No valid launch activity found in AndroidManifest.xml or launch.json');
 


### PR DESCRIPTION
I was testing modifications to the AOSP Settings app in VSCode.

When launching a debugger using a config similar to below, the error: "Launch failed: No valid launch activity found in AndroidManifest.xml or launch.json".

Code was not checking for a valid amStartArgs. Modified to accept a non-zero-length array for amStartArgs.

```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Launch Settings",
            "type": "android",
            "request": "launch",
            "targetDevice": "emulator-5554",
            "appSrcRoot": "${workspaceFolder}/packages/apps/Settings",
            "amStartArgs": [
                "-D",
                "--activity-brought-to-front",
                "-n com.android.settings/.homepage.SettingsHomepageActivity"
            ],
            "apkFile": "${workspaceRoot}/out/target/product/emulator_x86_64/system_ext/priv-app/Settings/Settings.apk"
        }
    ]
}
```